### PR TITLE
Avoid using unlogged tables

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc42/LargeCountJdbc42Test.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc42/LargeCountJdbc42Test.java
@@ -57,7 +57,7 @@ public class LargeCountJdbc42Test extends BaseTest4 {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    TestUtil.createUnloggedTable(con, "largetable", "a boolean");
+    TestUtil.createTempTable(con, "largetable", "a boolean");
   }
 
   @Override


### PR DESCRIPTION
We wrongly claimed to support unlogged tables and treated them as temp tables. This is now fixed in CedarDB, so we need to update JDBC tests. It was only used by one test, where we can get away using a temp table instead of an unlogged one.
